### PR TITLE
Make use of `shortauthors`

### DIFF
--- a/ccr.cls
+++ b/ccr.cls
@@ -35,7 +35,7 @@
 \newcommand{\keywords}[1]{\def\@keywords{#1}}
 \newcommand{\show@keywords}{\@keywords}
 
-\def\@shortauthors{(please specify \shortauthors)}
+\def\@shortauthors{etal}
 \newcommand{\shortauthors}[1]{\def\@shortauthors{#1}}
 \newcommand{\show@shortauthors}{\@shortauthors}
 
@@ -70,8 +70,8 @@
                \oldstylenums{\show@volume}.\oldstylenums{\show@pubnumber} (\oldstylenums{\show@pubyear}) 
                \oldstylenums{\thepage}--\oldstylenums{\pageref{LastPage}}\vspace{-.3em}\\
                \scriptsize\MakeUppercase{\sc\url{https://doi.org/\show@doi}}}}
-\fancyfoot[R]{\footnotesize© The authors. This is an open access article distributed under the \href{https://creativecommons.org/licenses/by/4.0/}{\textsc{cc by} \oldstylenums{4.0} license}}
-\fancyfoot[L]{\smallcaps{\thepage}}
+\fancyfoot[L]{\footnotesize© \show@shortauthors. \vspace{-.3em}\\ This is an open access article distributed under the \href{https://creativecommons.org/licenses/by/4.0/}{\textsc{cc by} \oldstylenums{4.0} license}}
+\fancyfoot[R]{\smallcaps{\thepage}}
 \renewcommand{\headrulewidth}{0pt}
 \renewcommand{\footrulewidth}{0pt}
 }

--- a/index.qmd
+++ b/index.qmd
@@ -7,6 +7,7 @@ author:
   - Somewhere Else
 - name: Author Two
   affiliation: University of Nowhere
+shortauthors: "One & Two"
 abstract: |
   This is the abstract.
   Hence, it is not concrete.

--- a/partials/before-body.tex
+++ b/partials/before-body.tex
@@ -9,3 +9,4 @@ $if(pubnumber)$\pubnumber{$pubnumber$}$endif$
 $if(pubyear)$\pubyear{$pubyear$}$endif$
 $if(firstpage)$\firstpage{$firstpage$}$endif$
 $if(doi)$\doi{$doi$}$endif$
+$if(shortauthors)$\shortauthors{$shortauthors$}$endif$


### PR DESCRIPTION
So that the footer on odd pages looks closer to the current layout

Also, the Page number should be on the right