### PR TITLE
Typo and other fixes

### DIFF
--- a/_extensions/ccr/ccr.cls
+++ b/_extensions/ccr/ccr.cls
@@ -1,6 +1,6 @@
 % Template for CCR Articles (very WIP)
 % 2023 Wouter van Atteveldt, Damian Trilling, Chung-hong Chan, Johannes B. Gruber
-% Version 0.03
+% Version 0.04
 % Please see https://github.com/vanatteveldt/ccr-quarto for the latest version of this file
 
 \ProvidesClass{ccr}[2023-02-03 v0.01]

--- a/_extensions/ccr/ccr.cls
+++ b/_extensions/ccr/ccr.cls
@@ -1,5 +1,5 @@
 % Template for CCR Articles (very WIP)
-% 2023 Wouter van Atteveldt, Damian Trilling, Chung-hong Chan
+% 2023 Wouter van Atteveldt, Damian Trilling, Chung-hong Chan, Johannes B. Gruber
 % Version 0.03
 % Please see https://github.com/vanatteveldt/ccr-quarto for the latest version of this file
 
@@ -138,7 +138,7 @@
 \fancyfoot[LE,RO]{\smallcaps{\thepage}}
 \fancyfoot[LO]{\smallcapsl{\show@shortauthors}}
 \if@review
-  \fancyfoot[RE]{\smallcaps{unpblished manuscript}}
+  \fancyfoot[RE]{\smallcaps{unpublished manuscript}}
 \else
   \fancyfoot[RE]{\smallcaps{vol. \oldstylenums{\show@volume}, no. \oldstylenums{\show@pubnumber}, \oldstylenums{\show@pubyear}}}
 \fi

--- a/_extensions/ccr/ccr.cls
+++ b/_extensions/ccr/ccr.cls
@@ -1,7 +1,7 @@
 % Template for CCR Articles (very WIP)
 % 2023 Wouter van Atteveldt, Damian Trilling, Chung-hong Chan, Johannes B. Gruber
 % Version 0.04
-% Please see https://github.com/vanatteveldt/ccr-quarto for the latest version of this file
+% Please see https://github.com/ccr-journal/ccr-quarto for the latest version of this file
 
 \ProvidesClass{ccr}[2023-02-03 v0.01]
 \NeedsTeXFormat{LaTeX2e}


### PR DESCRIPTION
I found a typo in my last PR. Prompted by that I also:

- bumped the version, since previous versions of this had no real review mode
- added myself as contributor at the top
- changed the URL in the class, although the old URL (https://github.com/vanatteveldt/ccr-quarto) is forwarded here