### PR TITLE
ccrtemplate.tex: Anonymise PDF metadata with the review option (resolves #12)

### DIFF
--- a/_extensions/ccr/ccrtemplate.tex
+++ b/_extensions/ccr/ccrtemplate.tex
@@ -295,12 +295,13 @@ $endif$
 $if(verbatim-in-note)$
 \VerbatimFootnotes % allow verbatim text in footnotes
 $endif$
+\makeatletter
 \hypersetup{
 $if(title-meta)$
   pdftitle={$title-meta$},
 $endif$
 $if(author-meta)$
-  pdfauthor={$author-meta$},
+  pdfauthor={{\if@review{Anonymous}\else{$author-meta$}\fi}},
 $endif$
 $if(lang)$
   pdflang={$lang$},
@@ -324,6 +325,7 @@ $else$
 $endif$
 $endif$
   pdfcreator={LaTeX via pandoc}}
+\makeatother
 
 $title.tex()$
 
@@ -355,3 +357,4 @@ $include-after$
 $endfor$
 $after-body.tex()$
 \end{document}
+


### PR DESCRIPTION
This small patch prevents the template from giving author information to `\hypersetup` when in review mode, preventing a leak of authors' names into the PDF metadata.

To do this it needs to introspect 'private' `\if@review` from `ccr.cls`, which involves wrapping the whole `\hypersetup` macro with `\makeatletter` / `\makeatother`. We could avoid this by changing its name and making it generally available, though as the template and the class are tightly tied together I don't think it matters particularly.