### PR TITLE
Use numbered superscripts for author affiliations

### DIFF
--- a/_extensions/ccr/ccr.cls
+++ b/_extensions/ccr/ccr.cls
@@ -237,14 +237,37 @@
 \vspace{.5in}
 
 \fussy
-\renewcommand*{\dotwo}[2]{%
-\noindent##1\\
-\noindent\textit{##2}
-\vspace{1em}\par
-}
 \if@review
 \else
+  % Step 1: Scan affiliations, assign a unique number to each distinct one
+  \newcounter{uniqaffil}%
+  \renewcommand*{\do}[1]{%
+    \@ifundefined{ccr@affil@\detokenize{##1}}{%
+      \stepcounter{uniqaffil}%
+      \expandafter\xdef\csname ccr@affil@\detokenize{##1}\endcsname{\theuniqaffil}%
+      \expandafter\gdef\csname ccr@affiltext@\theuniqaffil\endcsname{##1}%
+    }{}%
+  }%
+  \dolistloop{\listaffiliations}%
+  \edef\ccr@totalaffils{\theuniqaffil}%
+  %
+  % Step 2: Print authors with looked-up superscript numbers
+  \noindent
+  \def\@authsep{}%
+  \renewcommand*{\dotwo}[2]{%
+    \@authsep##1\textsuperscript{\csname ccr@affil@\detokenize{##2}\endcsname}%
+    \def\@authsep{, }%
+  }%
   \looptwo\listauthors\listaffiliations
+  \par\vspace{0.5em}
+  %
+  % Step 3: Print each unique affiliation once
+  {\small\itshape
+  \newcounter{affilprint}%
+  \@whilenum\value{affilprint}<\ccr@totalaffils\do{%
+    \stepcounter{affilprint}%
+    \noindent\textsuperscript{\theaffilprint}\,\csname ccr@affiltext@\theaffilprint\endcsname\par
+  }}%
 \fi
 
 \vspace{1em}


### PR DESCRIPTION
Deduplicate affiliations and display them with superscript numbers instead of repeating each one inline per author. Only applies in non-review mode.