### PR TITLE
Remove unused pstricks and allow PDF 1.7 inclusion

### DIFF
--- a/_extensions/ccr/ccr.cls
+++ b/_extensions/ccr/ccr.cls
@@ -12,6 +12,7 @@
 \DeclareOption{review}{\@reviewtrue}
 \ProcessOptions\relax
 
+\pdfminorversion=7
 \LoadClass[twoside]{article}
 
 %%%%%%%%%%%%% OVRERALL PAGE LAYOUT %%%%%%%%%%%%%%%%%%%
@@ -228,7 +229,6 @@
 
 %%%%%%%%%%%%%% Title page %%%%%%%%%%%%%%%%%%%%%
 \RequirePackage{calc}
-\RequirePackage{pstricks}
 \RequirePackage{hyphenat}
 
 \renewcommand{\maketitle}{%


### PR DESCRIPTION
## Summary
- Add `\pdfminorversion=7` before `\LoadClass` so pdflatex accepts PDF 1.7 files (common from draw.io, Inkscape, etc.)
- Remove `\RequirePackage{pstricks}` — no pstricks commands are used in the class and it causes "Non-PDF special ignored!" warnings

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)